### PR TITLE
Spevacus: Blacklist this is a test PR

### DIFF
--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -2619,3 +2619,4 @@ Q(?:uick)?B(?:ooks)?[\W_]*ProAdvisors?
 suonerie
 slot[\W_]*online
 hacklordjody(?:[\W_]*+(?:at[\W_]*+)?gmail(?:[\W_]*+(?:dot[\W_]*+)?com)?)?
+this is a test PR


### PR DESCRIPTION
[Spevacus](https://chat.stackexchange.com/users/430906) requests the blacklist of the keyword `this is a test PR`. See the MS search [here](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&body_is_regex=1&body=%28%3Fs%3A%5Cbthis+is+a+test+PR%5Cb%29) and the Stack Exchange search [in text](https://stackexchange.com/search?q=%22this+is+a+test+PR%22), [in URLs](https://stackexchange.com/search?q=url%3A%22this+is+a+test+PR%22), and [in code](https://stackexchange.com/search?q=code%3A%22this+is+a+test+PR%22).
<!-- METASMOKE-BLACKLIST-KEYWORD this is a test PR -->