### PR TITLE
Spevacus: Watch this-is-a-test

### DIFF
--- a/watched_keywords.txt
+++ b/watched_keywords.txt
@@ -62239,3 +62239,4 @@
 1716478745	Thomas Ward	beestars
 1716477103	Xander Henderson	Beestar
 1716481376	Mast	kmfusa\.info
+1716498411	Spevacus	this-is-a-test


### PR DESCRIPTION
[Spevacus](https://chat.stackexchange.com/users/430906) requests the watch of the watch_keyword `this-is-a-test`. See the MS search [here](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&body_is_regex=1&body=%28%3Fs%3A%5Cbthis-is-a-test%5Cb%29) and the Stack Exchange search [in text](https://stackexchange.com/search?q=%22this-is-a-test%22), [in URLs](https://stackexchange.com/search?q=url%3A%22this-is-a-test%22), and [in code](https://stackexchange.com/search?q=code%3A%22this-is-a-test%22).
<!-- METASMOKE-BLACKLIST-WATCH_KEYWORD this-is-a-test -->