### PR TITLE
Spevacus: Watch test-watch-to-close-1

### DIFF
--- a/watched_keywords.txt
+++ b/watched_keywords.txt
@@ -62240,3 +62240,4 @@
 1716477103	Xander Henderson	Beestar
 1716481376	Mast	kmfusa\.info
 1716821223	Spevacus	test-watch
+1716821965	Spevacus	test-watch-to-close-1


### PR DESCRIPTION
[Spevacus](https://chat.stackexchange.com/users/430906) requests the watch of the watch_keyword `test-watch-to-close-1`. See the MS search [here](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&body_is_regex=1&body=%28%3Fs%3A%5Cbtest-watch-to-close-1%5Cb%29) and the Stack Exchange search [in text](https://stackexchange.com/search?q=%22test-watch-to-close-1%22), [in URLs](https://stackexchange.com/search?q=url%3A%22test-watch-to-close-1%22), and [in code](https://stackexchange.com/search?q=code%3A%22test-watch-to-close-1%22).
<!-- METASMOKE-BLACKLIST-WATCH_KEYWORD test-watch-to-close-1 -->