### PR TITLE
Spevacus: Blacklist keyword testingthispr12345\.com

### DIFF
--- a/bad_keywords.txt
+++ b/bad_keywords.txt
@@ -3055,3 +3055,4 @@ cyberpunk1
 \A.{1,6}\bban me
 consider[\W_]*+banning[\W_]*+my[\W_]*+account
 (?<=\.)company\.site/$
+testingthispr12345\.com


### PR DESCRIPTION
[Spevacus](https://chat.stackexchange.com/users/430906) requests the blacklist of the keyword `testingthispr12345\.com`. See the MS search [here](https://metasmoke.erwaysoftware.com/search?utf8=%E2%9C%93&body_is_regex=1&body=%28%3Fs%3A%5Cbtestingthispr12345%5C.com%5Cb%29) and the Stack Exchange search [in text](https://stackexchange.com/search?q=%22testingthispr12345.com%22), [in URLs](https://stackexchange.com/search?q=url%3A%22testingthispr12345.com%22), and [in code](https://stackexchange.com/search?q=code%3A%22testingthispr12345.com%22).
<!-- METASMOKE-BLACKLIST-KEYWORD testingthispr12345\.com -->